### PR TITLE
Fix permision error and updated version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swipl:7.7.10
+FROM swipl:8.1.12
 LABEL maintainer "Dave Curylo <dave@curylo.org>"
 ADD https://github.com/SWI-Prolog/pengines/archive/master.tar.gz /
 RUN tar -xzf master.tar.gz && mv pengines-master pengines && rm master.tar.gz
@@ -6,6 +6,8 @@ RUN tar -xzf master.tar.gz && mv pengines-master pengines && rm master.tar.gz
 EXPOSE 3030
 # Set the pengines admin account to admin:admin
 RUN echo 'admin:$1$vUXiHMJy$DI1JHDLqTytUYGTHicJvE0' >>/pengines/passwd
+RUN useradd www
 WORKDIR /pengines
 ENTRYPOINT ["swipl"]
-CMD ["daemon.pl","--port=3030","--fork=false"]
+CMD ["daemon.pl","--port=3030","--fork=false", "--user=www"]
+


### PR DESCRIPTION
Before, when I tried to use this dockerfile, docker showed me the following error: "Fix ERROR: 'Refusing to run HTTP server as root': No permission to open server 'http'. To avoid this, I created a user to execute the `swipl` command. Also, I updated the swipl version to v8.1.12